### PR TITLE
Perspective fixes

### DIFF
--- a/lib/src/ui/photos/photos_page.dart
+++ b/lib/src/ui/photos/photos_page.dart
@@ -791,23 +791,24 @@ class RenderMontage extends RenderBox
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    final double distanceDx = math.tan(_perspectiveAngleRadians) * distance;
-    final double centerDx = size.width / 2;
+    final center = size / 2;
     assert(() {
       if (forceShowDebugInfo) {
         Paint paint = Paint()..color = const Color(0xffcc0000);
         context.canvas.drawLine(
-          Offset(centerDx, 0),
-          Offset(centerDx, size.height),
+          Offset(center.width, 0),
+          Offset(center.width, size.height),
           paint,
         );
       }
       return true;
     }());
-    Matrix4 transform = _perspectiveTransform.clone()
-      ..translate(centerDx + distanceDx, 0.0, distance)
+    Matrix4 transform = Matrix4.identity()
+      ..translate(center.width, center.height)
+      ..multiply(_perspectiveTransform)
+      ..translate(0.0, 0.0, distance)
       ..rotateY(rotation)
-      ..translate(-centerDx);
+      ..translate(-center.width, -center.height);
     PaintingContextCallback painter = paintForwards;
     if (rotation.abs() >= math.pi / 2.85 && rotation.abs() < math.pi * 1.48) {
       painter = paintBackwards;


### PR DESCRIPTION
@tvolkert

Took a quick look this weekend to work out the distortion I noticed on Thursday. :)

Quick screen recording/explainer here: https://www.youtube.com/watch?v=_fTL66bp798
[![Video explainer](https://img.youtube.com/vi/_fTL66bp798/0.jpg)](https://www.youtube.com/watch?v=_fTL66bp798)

Detection for when a montage card is going off the top of the screen:

```dart
    // In RenderMontageCard::paint

    var ctm = Matrix4.fromFloat64List(context.canvas.getTransform());
    var position = Vector4(x, y, z, 1.0);

    Vector4 transformedPosition = ctm * position;
    double distanceFromTop =
        (transformedPosition.y + size.height * scale) * transformedPosition.w;

    if (distanceFromTop < 0) {
        // Off screen
    }
```

For the "downward" camera frustum: I'm not sure if that was intentional, but since the top of the frustum was aligned with the Z axis, it would give you the benefit of not having to worry about the rotating animation when removing montage cards that have disappeared off the top of the screen.

Also took a frame capture with Impeller and Skia, and both renderers aren't rendering anything that's going offscreen. Skia is a bit heavier in the vertex stage, but Impeller seems to be a bit heavier in the fragment stage. YMMV.

Before:

https://github.com/tvolkert/photos/assets/919017/655ad71e-68ef-45bf-a273-aa91f41a9662


After:

https://github.com/tvolkert/photos/assets/919017/eb8a1476-3763-41e2-ac73-7ea481140892

